### PR TITLE
🫣↔️📜🍫 Hide horizontal scrollbar in proxy entries

### DIFF
--- a/src/renderer-process/proxy-view/ui/table-row-cell.tsx
+++ b/src/renderer-process/proxy-view/ui/table-row-cell.tsx
@@ -12,6 +12,9 @@ export const StyledTableCell = styled(TableCell)(({ theme }) => ({
     maxWidth: 70,
     overflow: 'auto',
     whiteSpace: 'nowrap',
+    '&::-webkit-scrollbar': {
+      display: 'none',
+    },
   },
 }));
 


### PR DESCRIPTION
## Problem:
Sometimes, for overflown text in the proxy entries list there is a visible scrollbar.
<img width="1440" height="876" alt="image" src="https://github.com/user-attachments/assets/f08200c5-374f-42ad-a1c6-4747c87eb830" />
Usually happens in MacOS if **System Settings → Accessibility → Appearance → Show scroll bars → Always** setting is selected.

This also happens on Windows:
<img width="480" height="358" alt="image" src="https://github.com/user-attachments/assets/220e12ae-e5c1-4cbc-9af2-67e9e1b6b5d9" />


## Solution:
This solution uses [::-webkit-scrollbar](https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-scrollbar) which is not standardized on all browsers but Electron bundles Chromium (Blink engine), which fully supports `::-webkit-scrollbar`.

After this fix table cells with overflow text will still be scrollable but without the visible scrollbars:

https://github.com/user-attachments/assets/1529e1d8-304a-4134-b78a-a1060a87f234


