### PR TITLE
🎒⛴️ Migrate from BrowserView to WebContentsView

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop-app",
   "productName": "Loadmill",
-  "version": "3.6.5",
+  "version": "3.7.0",
   "description": "The Loadmill desktop app",
   "author": {
     "name": "Loadmill Ltd.",

--- a/src/main-process/navigation-handler.ts
+++ b/src/main-process/navigation-handler.ts
@@ -1,4 +1,4 @@
-import { BrowserView, clipboard } from 'electron';
+import { clipboard, WebContentsView } from 'electron';
 
 import {
   sendFromMainWindowToRenderer,
@@ -15,7 +15,7 @@ import {
 
 import { subscribeToMainProcessMessage } from './main-events';
 
-export const subscribeToNavigationEvents = (webView: BrowserView): void => {
+export const subscribeToNavigationEvents = (webView: WebContentsView): void => {
   subscribeToMainProcessMessage(REFRESH_PAGE, () => {
     webView.webContents.reload();
   });

--- a/src/main-process/screen-size.ts
+++ b/src/main-process/screen-size.ts
@@ -1,4 +1,4 @@
-import { BrowserView, BrowserWindow } from 'electron';
+import { BrowserWindow, WebContentsView } from 'electron';
 
 import { TOGGLE_MAXIMIZE_WINDOW } from '../universal/constants';
 
@@ -17,7 +17,7 @@ export const subscribeToToggleMaximizeWindow = (mainWindow: BrowserWindow): void
 const TITLE_BAR_HEIGHT = 44;
 const HEIGHT_OFFSET = process.platform === 'win32' ? (TITLE_BAR_HEIGHT * 2) : TITLE_BAR_HEIGHT;
 
-export const setBrowserViewSize = (view: BrowserView, bounds: Electron.Rectangle): void => {
+export const setBrowserViewSize = (view: WebContentsView, bounds: Electron.Rectangle): void => {
   const { width, height } = bounds;
 
   view.setBounds({

--- a/src/main-process/views/agent-view.ts
+++ b/src/main-process/views/agent-view.ts
@@ -1,6 +1,6 @@
 import {
-  BrowserView,
   BrowserWindow,
+  WebContentsView,
 } from 'electron';
 
 import { subscribeToDownloadAgentLog } from '../agent/download-agent-log';
@@ -12,7 +12,7 @@ declare const AGENT_VIEW_PRELOAD_WEBPACK_ENTRY: string;
 
 export const createAgentView = (
   mainWindow: BrowserWindow,
-): BrowserView => {
+): WebContentsView => {
   const agent = createView(mainWindow, {
     openDevTools: true,
     preload: AGENT_VIEW_PRELOAD_WEBPACK_ENTRY,

--- a/src/main-process/views/index.ts
+++ b/src/main-process/views/index.ts
@@ -1,4 +1,4 @@
-import { BrowserView, BrowserWindow } from 'electron';
+import { BrowserWindow, WebContentsView } from 'electron';
 
 import {
   sendFromMainWindowToRenderer,
@@ -23,15 +23,15 @@ export const initializeViews = (window: BrowserWindow): void => {
   const loadmillWebView = createLoadmillWebView(mainWindow);
   const settingsView = createSettingsView(mainWindow);
   setViews(loadmillWebView, proxyView, agentView, settingsView);
-  mainWindow.setTopBrowserView(loadmillWebView);
+  mainWindow.contentView.addChildView(loadmillWebView);
   subscribeToSwitchView(mainWindow, loadmillWebView, proxyView, agentView, settingsView);
 };
 
 const setViews = (
-  loadmillWebView: BrowserView,
-  proxyView: BrowserView,
-  agentView: BrowserView,
-  settingsView: BrowserView,
+  loadmillWebView: WebContentsView,
+  proxyView: WebContentsView,
+  agentView: WebContentsView,
+  settingsView: WebContentsView,
 ) => {
   appendView(agentView, ViewName.AGENT);
   appendView(proxyView, ViewName.PROXY);
@@ -39,7 +39,7 @@ const setViews = (
   appendView(settingsView, ViewName.SETTINGS);
 };
 
-const appendView = (view: BrowserView, name: ViewName) => {
+const appendView = (view: WebContentsView, name: ViewName) => {
   views.push({ id: view.webContents.id, name, view });
 };
 
@@ -75,6 +75,6 @@ export const reloadViews = (): void => {
   });
 };
 
-export const getViewByName = (name: ViewName): BrowserView | undefined => {
+export const getViewByName = (name: ViewName): WebContentsView | undefined => {
   return views.find((view) => view.name === name)?.view;
 };

--- a/src/main-process/views/loadmill-web-app-browserview.ts
+++ b/src/main-process/views/loadmill-web-app-browserview.ts
@@ -1,6 +1,6 @@
 import {
-  BrowserView,
   BrowserWindow,
+  WebContentsView,
 } from 'electron';
 
 import {
@@ -21,7 +21,7 @@ declare const LOADMILL_VIEW_PRELOAD_WEBPACK_ENTRY: string; // webpack hack 😒
 
 export const createLoadmillWebView = (
   mainWindow: BrowserWindow,
-): BrowserView => {
+): WebContentsView => {
   const loadmillWebView = createView(mainWindow, {
     openDevTools: true,
     preload: LOADMILL_VIEW_PRELOAD_WEBPACK_ENTRY,

--- a/src/main-process/views/proxy-view.ts
+++ b/src/main-process/views/proxy-view.ts
@@ -1,6 +1,6 @@
 import {
-  BrowserView,
   BrowserWindow,
+  WebContentsView,
 } from 'electron';
 
 import { subscribeToFindOnPageEvents } from '../find-on-page';
@@ -15,7 +15,7 @@ declare const PROXY_VIEW_PRELOAD_WEBPACK_ENTRY: string;
 
 export const createProxyView = (
   mainWindow: BrowserWindow,
-): BrowserView => {
+): WebContentsView => {
   const proxyView = createView(mainWindow, {
     openDevTools: true,
     preload: PROXY_VIEW_PRELOAD_WEBPACK_ENTRY,

--- a/src/main-process/views/settings-view.ts
+++ b/src/main-process/views/settings-view.ts
@@ -1,6 +1,6 @@
 import {
-  BrowserView,
   BrowserWindow,
+  WebContentsView,
 } from 'electron';
 
 import { subscribeToSettingsEvents } from '../settings';
@@ -12,7 +12,7 @@ declare const SETTINGS_VIEW_PRELOAD_WEBPACK_ENTRY: string;
 
 export const createSettingsView = (
   mainWindow: BrowserWindow,
-): BrowserView => {
+): WebContentsView => {
   const settingsView = createView(mainWindow, {
     openDevTools: true,
     preload: SETTINGS_VIEW_PRELOAD_WEBPACK_ENTRY,

--- a/src/main-process/views/switch-views.ts
+++ b/src/main-process/views/switch-views.ts
@@ -1,4 +1,4 @@
-import { BrowserView, BrowserWindow } from 'electron';
+import { BrowserWindow, WebContentsView } from 'electron';
 
 import { MainMessage } from '../../types/messaging';
 import { ViewName } from '../../types/views';
@@ -6,17 +6,17 @@ import { SWITCH_VIEW } from '../../universal/constants';
 import { subscribeToMainProcessMessage } from '../main-events';
 import { setBrowserViewSize } from '../screen-size';
 
-export const switchView = (mainWindow: BrowserWindow, view: BrowserView): void => {
+export const switchView = (mainWindow: BrowserWindow, view: WebContentsView): void => {
   setBrowserViewSize(view, mainWindow.getBounds());
-  mainWindow.setTopBrowserView(view);
+  mainWindow.contentView.addChildView(view);
 };
 
 export const subscribeToSwitchView = (
   mainWindow: BrowserWindow,
-  loadmillWebView: BrowserView,
-  proxyView: BrowserView,
-  agentView: BrowserView,
-  settingsView: BrowserView,
+  loadmillWebView: WebContentsView,
+  proxyView: WebContentsView,
+  agentView: WebContentsView,
+  settingsView: WebContentsView,
 ): void => {
   subscribeToMainProcessMessage(SWITCH_VIEW, (_event: Electron.IpcMainEvent, { view }: MainMessage['data']) => {
     switch (view) {

--- a/src/main-process/views/view-factory.ts
+++ b/src/main-process/views/view-factory.ts
@@ -1,4 +1,4 @@
-import { app, BrowserView, BrowserWindow } from 'electron';
+import { app, BrowserWindow, WebContentsView } from 'electron';
 
 import { RESIZE } from '../../universal/constants';
 import { subscribeToFindOnPageEvents } from '../find-on-page';
@@ -12,13 +12,13 @@ export const createView = (
     url,
     openDevTools = false,
   }: ViewOptions,
-): BrowserView => {
-  const view = new BrowserView({
+): WebContentsView => {
+  const view = new WebContentsView({
     webPreferences: {
       preload,
     },
   });
-  mainWindow.addBrowserView(view);
+  mainWindow.contentView.addChildView(view);
   setOpenLinksInBrowser(view.webContents);
   const handleWindowResize = (_e: Electron.Event) => {
     setBrowserViewSize(view, mainWindow.getBounds());

--- a/src/types/views.ts
+++ b/src/types/views.ts
@@ -1,4 +1,4 @@
-import { BrowserView } from 'electron';
+import { WebContentsView } from 'electron';
 
 export enum ViewName {
   AGENT = 'agent',
@@ -10,5 +10,5 @@ export enum ViewName {
 export type View = {
   id: number;
   name: ViewName;
-  view: BrowserView;
+  view: WebContentsView;
 };


### PR DESCRIPTION
Apparently, [BrowserView class is deprecated](https://www.electronjs.org/docs/latest/api/browser-view).
Following this guideline - https://www.electronjs.org/blog/migrate-to-webcontentsview, we are replacing all usage of BrowserView in the app to [WebContentsView](https://www.electronjs.org/docs/latest/api/web-contents-view).